### PR TITLE
Refactor: Return actual client objects for team members

### DIFF
--- a/src/GhostBot/client_window.py
+++ b/src/GhostBot/client_window.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import contextlib
 import math
 import time
 from ctypes.wintypes import LPARAM, WPARAM
+from typing import Self
 
 import cv2
 import numpy as np
@@ -13,6 +16,7 @@ import win32con
 import win32gui
 import win32process
 import win32ui
+from PIL.ImageTk import TYPE_CHECKING
 
 from pymem.exception import MemoryReadError, ProcessError
 from win32con import SM_CYCAPTION
@@ -25,6 +29,9 @@ from GhostBot.map_navigation import location_to_zone_map
 
 TARGET_MAX_HP=597
 TARGET_MIN_HP=461
+
+if TYPE_CHECKING:
+    from GhostBot.controller.bot_controller import BotController
 
 
 def get_pointer(self, base, offsets):
@@ -73,7 +80,13 @@ class Win32ClientWindow(AbstractClientWindow):
 
         with contextlib.suppress(TypeError):
             self.set_window_name()
+        self._bot_controller: BotController | None = None
         # FIXME: wrap all getters in a retry DC check loop
+
+    def with_bot_controller(self, _bot_controller: BotController) -> Self:
+        self.logger.debug("%s :: setting bot controller [%s]", self.name, _bot_controller.__class__.__name__)
+        self._bot_controller = _bot_controller
+        return self
 
     @property
     def identifier(self):
@@ -216,7 +229,7 @@ class Win32ClientWindow(AbstractClientWindow):
         return self.pointers.get_team_size()
 
     @property
-    def team_members(self) -> list[str]:  # TODO: this should return a list of references to ClientWindow
+    def team_members(self) -> list[Self]:
         check = [
             self.pointers.team_name_1,
             self.pointers.team_name_2,
@@ -224,7 +237,7 @@ class Win32ClientWindow(AbstractClientWindow):
             self.pointers.team_name_4,
         ]
 
-        return [check[m]() for m in range(self.team_size - 1)]
+        return [self._bot_controller.clients.get(check[m]() or "") for m in range(self.team_size - 1)]
 
     @property
     def pet_active(self) -> bool:

--- a/src/GhostBot/controller/bot_controller.py
+++ b/src/GhostBot/controller/bot_controller.py
@@ -4,7 +4,7 @@ import math
 import threading
 import time
 from abc import abstractmethod, ABC
-from typing import Generator, TYPE_CHECKING
+from typing import Generator, TYPE_CHECKING, Self
 
 from operator import mul, add
 
@@ -291,7 +291,7 @@ class BotController(ABC):
 
     def add_client(self, client: BotClientWindow) -> BotClientWindow:
         with lock:
-            self.clients[client.name] = client
+            self.clients[client.name] = client.with_bot_controller(self)
             self.server.send_to_all(self.server.bot_controller_clients_message)
             return client
 

--- a/src/GhostBot/functions/fairy.py
+++ b/src/GhostBot/functions/fairy.py
@@ -54,6 +54,6 @@ class Fairy(Locational):
         """
         return {
             k: v for k, v in {
-                i: self._bot_controller.clients.get(name) for i, name in enumerate(self._client.team_members)
+                i: client for i, client in enumerate(self._client.team_members)
             }.items() if v and not v.disconnected
         }

--- a/tests/test_client_window.py
+++ b/tests/test_client_window.py
@@ -1,6 +1,8 @@
 import os
 
 import pytest
+from GhostBot.controller.threaded_bot_controller import ThreadedBotController
+
 from mocks.mock_client import client
 
 from GhostBot.image_finder import ImageFinder
@@ -41,3 +43,12 @@ def test_inventory_context_manager(monkeypatch, client):
     with client.inventory():
         assert _calls == ["open_inventory"]
     assert _calls == ["open_inventory", "close_inventory"]
+
+@pytest.mark.skip("local testing only for now")
+def test_team_members():
+    bc = ThreadedBotController()
+    bc._running = True
+    bc._scan_for_clients()
+    wyp = bc.clients.get('bot_name')
+    print(wyp.team_size)
+    assert not [t.team_members[0].name for t in wyp.team_members]


### PR DESCRIPTION
The `Win32ClientWindow.team_members` property now returns `ClientWindow` instances instead of just their names. This allows for direct interaction with team members' client objects, simplifying subsequent logic (e.g., in fairy functions). Each `ClientWindow` is now given a reference to its `BotController` to enable direct lookup of other clients.